### PR TITLE
Add Wild Words engine (The Wildsea) support

### DIFF
--- a/help-text.md
+++ b/help-text.md
@@ -10,6 +10,8 @@ Sparks' dice-rolling commands are all subcommands of `/roll`. For example, `/rol
 
 - `/roll pbta`: rolls a Powered by the Apocalypse move. Requires the stat, including any bonuses to the roll (i.e. +1 forwards/ongoings, move-related bonuses, etc.)
 
+- `/roll wild`: rolls a Wild Words roll. Requires both the number of d6s to roll and the type of roll, and optionally the number of dice to cut.
+
 - `/roll custom`: rolls any number of dice with any number of sides. Requires the number of dice and the number of sides per die (all dice will be rolled with the same number of sides.) Doesn't accept negative numbers.
 
 - `/buzz`: Sparks will reply with "Zap!"

--- a/src/commands/roll.ts
+++ b/src/commands/roll.ts
@@ -93,14 +93,12 @@ export const execute = async (interaction: Interaction) => {
     case "wild": {
       const pool = interaction.options.getInteger("pool");
       const rollType = interaction.options.getString("type") as WildType;
-      const cut = interaction.options.getInteger("cut");
+      const cut = interaction.options.getInteger("cut") as number;
       if (
         rollType === null ||
         rollType === undefined ||
         pool === null ||
-        pool === undefined ||
-        cut === null ||
-        cut === undefined
+        pool === undefined
       )
         return;
         const rolls = pool === 0 ? rollDice(1,6) : rollDice(pool,6);

--- a/src/commands/roll.ts
+++ b/src/commands/roll.ts
@@ -6,7 +6,7 @@ import {
   ColorResolvable,
 } from "discord.js";
 //various dice-based roll utilities
-import { rollDice, RollResponse, ForgedType, RollStatus } from "../utils/lib";
+import { rollDice, RollResponse, ForgedType, WildType, RollStatus } from "../utils/lib";
 import * as interpreters from "../interpreters/interpreter";
 //commands
 import * as inputs from "../utils/rollCommandBuilders";
@@ -17,7 +17,8 @@ export const data = new SlashCommandBuilder()
   .addSubcommandGroup(inputs.sbrCommand)
   .addSubcommand(inputs.forgedCommand)
   .addSubcommand(inputs.customRollCommand)
-  .addSubcommand(inputs.pbtaCommand);
+  .addSubcommand(inputs.pbtaCommand)
+  .addSubcommand(inputs.wildCommand);
 
 export const execute = async (interaction: Interaction) => {
   if (!interaction.isRepliable || !interaction.isChatInputCommand()) return;
@@ -88,6 +89,23 @@ export const execute = async (interaction: Interaction) => {
       const rolls = rollDice(2, 6);
       response = interpreters.pbtaMove(rolls, stat);
       break;
+    }
+    case "wild": {
+      const pool = interaction.options.getInteger("pool");
+      const rollType = interaction.options.getString("type") as WildType;
+      const cut = interaction.options.getInteger("cut");
+      if (
+        rollType === null ||
+        rollType === undefined ||
+        pool === null ||
+        pool === undefined ||
+        cut === null ||
+        cut === undefined
+      )
+        return;
+        const rolls = pool === 0 ? rollDice(1,6) : rollDice(pool,6);
+        response = interpreters.wildDice(rolls, rollType, pool === 0,cut);
+        break;
     }
   }
 

--- a/src/interpreters/interpreter.ts
+++ b/src/interpreters/interpreter.ts
@@ -2,3 +2,4 @@ export { customRoll } from "./customDice";
 export { falloutTest, skillCheck } from "./sbrDice";
 export { forgedDice } from "./forgedDice";
 export { pbtaMove } from "./pbtaDice";
+export { wildDice } from "./wildDice";

--- a/src/interpreters/wildDice.ts
+++ b/src/interpreters/wildDice.ts
@@ -287,11 +287,27 @@ export const wildDice = (
           switch (rollType) {
 
               case WildType.Attack:
-                descText += "\n\n**Twist... or Critical**\n Unexpected narrative effect/critical with increased impact."
+                descText += "\n\n**Twist... or Critical**\nUnexpected narrative effect/critical with increased impact.";
                 break;
 
               case WildType.Defense:
-                descText += "\n\n**Twist... or Counter**\n Unexpected narrative effect, or counter with a mark of damage against them (if in range)."  
+                descText += "\n\n**Twist... or Counter**\nUnexpected narrative effect, or counter with a mark of damage against them (if in range).";  
+                break;
+
+              case WildType.Acquisition:
+                descText += "\n\n**Twist**\nGain a resource with a unique or positive tag suggested by you or another player.";
+                break;
+
+              case WildType.Creation:
+                descText += "\n\n**Twist**\nCreation has small, unexpected benefit in addition to the usual result."
+                break;
+
+              case WildType.Recovery:
+                descText += "\n\n**Twist**\nYou don't consume the resource used to carry out your recovery.";
+                break;
+
+              case WildType.Ratings:
+                descText += "\n\n**Twist**\nAn unexpected event in addition to the result.";
                 break;
 
               default:

--- a/src/interpreters/wildDice.ts
+++ b/src/interpreters/wildDice.ts
@@ -14,7 +14,20 @@ export const wildDice = (
   cut?: number
 ): RollResponse => {
 
+
+  // TODO: cut
+
     const pool = zeroD ? 0 : rolls.dice.length;
+
+    const doubles: boolean = (() => {
+
+      if (rolls.dice.length !== new Set(rolls.dice).size) {
+        return true;
+      }
+      return false;
+    })();
+
+
     const score = rolls.max;
     
     const status: RollStatus =
@@ -36,11 +49,11 @@ export const wildDice = (
           return (() => {
             switch (status) {
               case RollStatus.Full:
-                return "Peace";
+                return `(${rollType}) Peace`;
               case RollStatus.Mixed:
-                return "Order";
+                return `(${rollType}) Order`;
               case RollStatus.Failure:
-                return "Nature";
+                return `(${rollType}) Nature`;
               default:
                 throw new UnreachableCaseError(status);
             }
@@ -49,11 +62,11 @@ export const wildDice = (
           return (() => {
             switch (status) {
               case RollStatus.Full:
-                return "Clear Skies";
+                return `(${rollType}) Clear Skies`;
               case RollStatus.Mixed:
-                return "Continuation";
+                return `(${rollType}) Continuation`;
               case RollStatus.Failure:
-                return "A Change for the Worse";
+                return `(${rollType}) A Change for the Worse`;
               default:
                 throw new UnreachableCaseError(status);
               }
@@ -61,21 +74,202 @@ export const wildDice = (
         default:
           return (() => {
             switch (status) {
+
               case RollStatus.Full:
-                return "Triumph!";
+                return `(${rollType}) Triumph${
+                  doubles ? " with a twist" : ""
+                }!`;
+
               case RollStatus.Mixed:
-                return "Conflict!";
+                return `(${rollType}) Conflict${
+                  doubles ? " with a twist" : ""
+                }!`; 
+                
               case RollStatus.Failure:
-                return "Disaster!";
-              default:
+                return `(${rollType}) Disaster${
+                  doubles ? " with a twist" : ""
+                }!`;
+
+                default:
                 throw new UnreachableCaseError(status);
               }
             })();
+ 
       ;}
-      
+
     })();
 
-        const description = "test";
+    const description =
+       (() => {
+
+          switch (rollType) {
+
+            case WildType.Action:
+              return (() => {
+              switch (status) {
+                case RollStatus.Full:
+                  return `Complete success, no drawbacks. Mark/clear a box on a track.${
+                    doubles ? " (Twist) Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
+                  }`;
+                case RollStatus.Mixed:
+                  return `Success with a drawback. Usually marks/ clears a box.${
+                    doubles ? " (Twist) Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
+                  }`;
+                case RollStatus.Failure:
+                  return `Failure and narrative complication or drawback. Usually doesn't mark/clear a box.${
+                    doubles ? " (Twist) Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
+                  }`;
+                default:
+                  throw new UnreachableCaseError(status)}
+              })(); 
+              
+            case WildType.Attack:
+              return (() => {
+                switch (status) {
+                  case RollStatus.Full:
+                    return `Powerful blow. Deal damage and might inflict an effect.${
+                      doubles ? " (Twist... or Critical) Unexpected narrative effect/critical with increased impact." : ""
+                    }`;
+                  case RollStatus.Mixed:
+                    return `Attack deals damage and maybe associated effect, but you might take some damage, suffer an effect, lose a resource or be put in a less favourable position.${
+                      doubles ? " (Twist... or Critical) Unexpected narrative effect/critical with increased impact." : ""
+                    }`;
+                  case RollStatus.Failure:
+                    return `Failure and narrative complication or drawback. Usually doesn't mark/clear a box.${
+                      doubles ? " (Twist... or Critical) Unexpected narrative effect/critical with increased impact." : ""
+                    }`;
+                  default:
+                    throw new UnreachableCaseError(status)}
+                })();
+
+            case WildType.Defense:
+              return (() => {
+                switch (status) {
+                  case RollStatus.Full:
+                    return `Completely avoid the threat (though some powerful opponents may have aspects that make even a triumph dangerous).${
+                      doubles ? " (Twist...or Counter) Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
+                    }`;
+                  case RollStatus.Mixed:
+                    return `Avoid the worst but take damage, an effect, a negative change in position, or destruction (or temporary denial) of a resource.${
+                      doubles ? " (Twist...or Counter) Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
+                    }`;
+                  case RollStatus.Failure:
+                    return `Take damage, and likely associated effect and loss of resource or position as well.${
+                      doubles ? " (Twist...or Counter) Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
+                    }`;
+                  default:
+                    throw new UnreachableCaseError(status)}
+                  })();
+
+            case WildType.Resource:
+              return (() => {
+                switch (status) {
+                  case RollStatus.Full:
+                    return `Gain a solid untainted resource.${
+                      doubles ? " (Twist) Gain a resource with a unique or positive tag suggested by you or another player." : ""
+                    }`;
+                  case RollStatus.Mixed:
+                    return `Gain a resource with a negative tag.${
+                      doubles ? " (Twist) Gain a resource with a unique or positive tag suggested by you or another player." : ""
+                    }`;
+                  case RollStatus.Failure:
+                    return `Resource not found or ruined during collection.${
+                      doubles ? " (Twist) Gain a resource with a unique or positive tag suggested by you or another player." : ""
+                    }`;
+                  default:
+                    throw new UnreachableCaseError(status)}
+                  })();
+
+              case WildType.Creation:
+                return (() => {
+                  switch (status) {
+                    case RollStatus.Full:
+                      return `Recipient gains temporary benefit related to resources used.${
+                        doubles ? " (Twist) Creation has small, unexpected benefit in addition to the usual result." : ""
+                      }`;
+                    case RollStatus.Mixed:
+                      return `Recipient gains temporary 2-track aspect with downsides, or no downside, but it doesn't quite do what was intended.${
+                        doubles ? " (Twist) Creation has small, unexpected benefit in addition to the usual result." : ""
+                      }`;
+                    case RollStatus.Failure:
+                      return `Creation might be a bizarre ornament/culinary curiosity, but gives no benefits.${
+                        doubles ? " (Twist) Creation has small, unexpected benefit in addition to the usual result." : ""
+                      }`;
+                    default:
+                      throw new UnreachableCaseError(status)}
+                    })();
+
+              case WildType.Recovery:
+                return (() => {
+                  switch (status) {
+                    case RollStatus.Full:
+                      return `Heal two marks of damage to an aspect, ship rating, injury track or mire.${
+                        doubles ? " (Twist) You don’t consume the resource used to carry out your recovery." : ""
+                      }`;
+                    case RollStatus.Mixed:
+                      return `Heal one mark of damage to an aspect, ship rating, injury track or mire.${
+                        doubles ? " (Twist) You don’t consume the resource used to carry out your recovery." : ""
+                      }`;
+                    case RollStatus.Failure:
+                      return `Add an extra mark of damage to an aspect, ship rating, injury track or mire.${
+                        doubles ? " (Twist) You don’t consume the resource used to carry out your recovery." : ""
+                      }`;
+                    default:
+                      throw new UnreachableCaseError(status)}
+                    })();
+
+                case WildType.Ratings:
+                  return (() => {
+                    switch (status) {
+                      case RollStatus.Full:
+                        return `Bypass the obstacle safely.${
+                          doubles ? " (Twist) An unexpected event in addition to the result." : ""
+                        }`;
+                      case RollStatus.Mixed:
+                        return `Bypass the obstacle but mark 1 Rating damage.${
+                          doubles ? " (Twist) An unexpected event in addition to the result." : ""
+                        }`;
+                      case RollStatus.Failure:
+                        return `Fail to bypass the obstacle and mark 1 Rating damage.${
+                          doubles ? " (Twist) An unexpected event in addition to the result." : ""
+                        }`;
+                      default:
+                        throw new UnreachableCaseError(status)}
+                      })();
+
+                // Watch and Weather-Watching don't have twist results
+
+                case WildType.Watch:
+                  return (() => {
+                    switch (status) {
+                      case RollStatus.Full:
+                        return `Montage, Meeting, Tall Tale (gain a Whisper), Tree Shanty, Undercrew Issue, Reflection (heal Mire)`;
+                      case RollStatus.Mixed:
+                        return `Nearby Ship, Outpost, Survivor Needing Rescue, Wreck or Ruin, Cache of Cargo/Supplies, Conspiracy`;
+                      case RollStatus.Failure:
+                        return `Weather, Natural Feature, Wonder (heal Mire), Horror, Unsettled Landfall, True Wilds`;
+                      default:
+                        throw new UnreachableCaseError(status)}
+                      })();
+
+                case WildType.Weather:
+                  return (() => {
+                    switch (status) {
+                      case RollStatus.Full:
+                        return `Weather clears.`;
+                      case RollStatus.Mixed:
+                        return `Weather continues as it is.`;
+                      case RollStatus.Failure:
+                        return `Driving rain/hail (lowers visibility), blazing sunshine (potential heathstroke), living storm or bizarre weather phenomenon.`;
+                      default:
+                        throw new UnreachableCaseError(status)}
+                      })();
+
+
+              default:
+                throw new UnreachableCaseError(rollType)}
+        })();     
+
 
   return {
     title,

--- a/src/interpreters/wildDice.ts
+++ b/src/interpreters/wildDice.ts
@@ -105,210 +105,187 @@ export const wildDice = (
 
     const description =
        (() => {
+        let descText = "";
 
-          switch (rollType) {
-            // there is probably a way to avoid this deduplication for the twists text
-            case WildType.Action:
+        switch (rollType) {
 
-              return (() => {
-
-              switch (status) {
-
+          case WildType.Action:
+            switch (status) {
                 case RollStatus.Full:
-                  return `Complete success, no drawbacks. Mark/clear a box on a track.${
-                    doubles ? " \n\n**(Twist)**\n Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
-                  }`;
+                  descText += "Complete success, no drawbacks. Mark/clear a box on a track.";
+                  break;
 
                 case RollStatus.Mixed:
-                  return `Success with a drawback. Usually marks/ clears a box.${
-                    doubles ? " \n\n**(Twist)**\n Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
-                  }`;
+                  descText += "Success with a drawback. Usually marks/ clears a box.";
+                  break;
 
                 case RollStatus.Failure:
-                  return `Failure and narrative complication or drawback. Usually doesn't mark/clear a box.${
-                    doubles ? " \n\n**(Twist)**\n Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
-                  }`;
+                  descText += "Failure and narrative complication or drawback. Usually doesn't mark/clear a box."
+                  break;
+            }
+            break;
 
-                default:
-                  throw new UnreachableCaseError(status)}
-              })(); 
-              
-            case WildType.Attack:
-              return (() => {
-                switch (status) {
+          case WildType.Attack:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Powerful blow. Deal damage and might inflict an effect.";
+                  break;
 
-                  case RollStatus.Full:
-                    return `Powerful blow. Deal damage and might inflict an effect.${
-                      doubles ? " \n\n**(Twist... or Critical)**\n Unexpected narrative effect/critical with increased impact." : ""
-                    }`;
+                case RollStatus.Mixed:
+                  descText += "Attack deals damage and maybe associated effect, but you might take some damage, suffer an effect, lose a resource or be put in a less favourable position.";
+                  break;
 
-                  case RollStatus.Mixed:
-                    return `Attack deals damage and maybe associated effect, but you might take some damage, suffer an effect, lose a resource or be put in a less favourable position.${
-                      doubles ? " \n\n**(Twist... or Critical)**\n Unexpected narrative effect/critical with increased impact." : ""
-                    }`;
+                case RollStatus.Failure:
+                  descText += "Attack misses or does no damage. You definitely take some damage or an effect, and might lose a resource or be put in a less favourable position too."
+                  break;
+            }
+            break;
+  
+          case WildType.Defense:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Completely avoid the threat (though some powerful opponents may have aspects that make even a triumph dangerous).";
+                  break;
 
-                  case RollStatus.Failure:
-                    return `Attack misses or does no damage. You definitely take some damage or an effect, and might lose a resource or be put in a less favourable position too.${
-                      doubles ? " \n\n**(Twist... or Critical)**\n Unexpected narrative effect/critical with increased impact." : ""
-                    }`;
+                case RollStatus.Mixed:
+                  descText += "Avoid the worst but take damage, an effect, a negative change in position, or destruction (or temporary denial) of a resource.";
+                  break;
 
-                  default:
-                    throw new UnreachableCaseError(status)}
-                })();
+                case RollStatus.Failure:
+                  descText += "Take damage, and likely associated effect and loss of resource or position as well."
+                  break;
+            }
+            break;
 
-            case WildType.Defense:
-              return (() => {
-                switch (status) {
+          case WildType.Acquisition:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Gain a solid untainted resource.";
+                  break;
 
-                  case RollStatus.Full:
-                    return `Completely avoid the threat (though some powerful opponents may have aspects that make even a triumph dangerous).${
-                      doubles ? " \n\n**(Twist... or Counter)**\n Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
-                    }`;
+                case RollStatus.Mixed:
+                  descText += "Gain a resource with a negative tag.";
+                  break;
 
-                  case RollStatus.Mixed:
-                    return `Avoid the worst but take damage, an effect, a negative change in position, or destruction (or temporary denial) of a resource.${
-                      doubles ? " \n\n**(Twist... or Counter)**\n Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
-                    }`;
+                case RollStatus.Failure:
+                  descText += "Resource not found or ruined during collection."
+                  break;
+            }
+            break;
 
-                  case RollStatus.Failure:
-                    return `Take damage, and likely associated effect and loss of resource or position as well.${
-                      doubles ? " \n\n**(Twist... or Counter)**\n Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
-                    }`;
+          case WildType.Creation:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Recipient gains temporary benefit related to resources used.";
+                  break;
 
-                  default:
-                    throw new UnreachableCaseError(status)}
-                  })();
+                case RollStatus.Mixed:
+                  descText += "Recipient gains temporary 2-track aspect with downsides, or no downside, but it doesn't quite do what was intended.";
+                  break;
 
-            case WildType.Acquisition:
-              return (() => {
-                switch (status) {
+                case RollStatus.Failure:
+                  descText += "Creation might be a bizarre ornament/culinary curiosity, but gives no benefits."
+                  break;
+            }
+            break;
 
-                  case RollStatus.Full:
-                    return `Gain a solid untainted resource.${
-                      doubles ? " \n\n**(Twist)**\n Gain a resource with a unique or positive tag suggested by you or another player." : ""
-                    }`;
+          case WildType.Recovery:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Heal two marks of damage to an aspect, ship rating, injury track or mire.";
+                  break;
 
-                  case RollStatus.Mixed:
-                    return `Gain a resource with a negative tag.${
-                      doubles ? " \n\n**(Twist)**\n Gain a resource with a unique or positive tag suggested by you or another player." : ""
-                    }`;
+                case RollStatus.Mixed:
+                  descText += "Heal one mark of damage to an aspect, ship rating, injury track or mire.";
+                  break;
 
-                  case RollStatus.Failure:
-                    return `Resource not found or ruined during collection.${
-                      doubles ? " \n\n**(Twist)**\n Gain a resource with a unique or positive tag suggested by you or another player." : ""
-                    }`;
+                case RollStatus.Failure:
+                  descText += "Add an extra mark of damage to an aspect, ship rating, injury track or mire."
+                  break;
+            }
+            break;
 
-                  default:
-                    throw new UnreachableCaseError(status)}
-                  })();
+          case WildType.Ratings:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Bypass the obstacle safely.";
+                  break;
 
-            case WildType.Creation:
-              return (() => {
-                switch (status) {
+                case RollStatus.Mixed:
+                  descText += "Bypass the obstacle but mark 1 Rating damage.";
+                  break;
 
-                  case RollStatus.Full:
-                    return `Recipient gains temporary benefit related to resources used.${
-                      doubles ? " \n\n**(Twist)**\n Creation has small, unexpected benefit in addition to the usual result." : ""
-                    }`;
+                case RollStatus.Failure:
+                  descText += "Fail to bypass the obstacle and mark 1 Rating damage."
+                  break;
+            }
+            break;
 
-                  case RollStatus.Mixed:
-                    return `Recipient gains temporary 2-track aspect with downsides, or no downside, but it doesn't quite do what was intended.${
-                      doubles ? " \n\n**(Twist)**\n Creation has small, unexpected benefit in addition to the usual result." : ""
-                    }`;
+          case WildType.Watch:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Montage, Meeting, Tall Tale (gain a Whisper), Tree Shanty, Undercrew Issue, Reflection (heal Mire)";
+                  break;
 
-                  case RollStatus.Failure:
-                    return `Creation might be a bizarre ornament/culinary curiosity, but gives no benefits.${
-                      doubles ? " \n\n**(Twist)**\n Creation has small, unexpected benefit in addition to the usual result." : ""
-                    }`;
+                case RollStatus.Mixed:
+                  descText += "Nearby Ship, Outpost, Survivor Needing Rescue, Wreck or Ruin, Cache of Cargo/Supplies, Conspiracy";
+                  break;
 
-                  default:
-                    throw new UnreachableCaseError(status)}
-                  })();
-
-            case WildType.Recovery:
-              return (() => {
-                switch (status) {
-
-                  case RollStatus.Full:
-                    return `Heal two marks of damage to an aspect, ship rating, injury track or mire.${
-                      doubles ? " \n\n**(Twist)**\n You don't consume the resource used to carry out your recovery." : ""
-                    }`;
-
-                  case RollStatus.Mixed:
-                    return `Heal one mark of damage to an aspect, ship rating, injury track or mire.${
-                      doubles ? " \n\n**(Twist)**\n You don't consume the resource used to carry out your recovery." : ""
-                    }`;
-
-                  case RollStatus.Failure:
-                    return `Add an extra mark of damage to an aspect, ship rating, injury track or mire.${
-                      doubles ? " \n\n**(Twist)**\n You don't consume the resource used to carry out your recovery." : ""
-                    }`;
-
-                  default:
-                    throw new UnreachableCaseError(status)}
-                  })();
-
-            case WildType.Ratings:
-              return (() => {
-                switch (status) {
-
-                  case RollStatus.Full:
-                    return `Bypass the obstacle safely.${
-                      doubles ? " \n\n**(Twist)**\n An unexpected event in addition to the result." : ""
-                    }`;
-
-                  case RollStatus.Mixed:
-                    return `Bypass the obstacle but mark 1 Rating damage.${
-                      doubles ? " \n\n**(Twist)**\n An unexpected event in addition to the result." : ""
-                    }`;
-
-                  case RollStatus.Failure:
-                    return `Fail to bypass the obstacle and mark 1 Rating damage.${
-                      doubles ? " \n\n**(Twist)**\n An unexpected event in addition to the result." : ""
-                    }`;
-
-                  default:
-                    throw new UnreachableCaseError(status)}
-                  })();
-
-                // Watch and Weather-Watching don't have twist results
-
-            case WildType.Watch:
-              return (() => {
-                switch (status) {
-
-                  case RollStatus.Full:
-                    return `Montage, Meeting, Tall Tale (gain a Whisper), Tree Shanty, Undercrew Issue, Reflection (heal Mire)`;
-             
-                  case RollStatus.Mixed:
-                    return `Nearby Ship, Outpost, Survivor Needing Rescue, Wreck or Ruin, Cache of Cargo/Supplies, Conspiracy`;
-            
-                  case RollStatus.Failure:
-                    return `Weather, Natural Feature, Wonder (heal Mire), Horror, Unsettled Landfall, True Wilds`;
-            
-                  default:
-                    throw new UnreachableCaseError(status)}
-                  })();
+                case RollStatus.Failure:
+                  descText += "Weather, Natural Feature, Wonder (heal Mire), Horror, Unsettled Landfall, True Wilds"
+                  break;
+            }
+            break;
 
             case WildType.Weather:
-              return (() => {
-                switch (status) {
-
+              switch (status) {
                   case RollStatus.Full:
-                    return `Weather clears.`;
-                  
+                    descText += "Weather clears.";
+                    break;
+  
                   case RollStatus.Mixed:
-                    return `Weather continues as it is.`;
-                  
+                    descText += "Weather continues as it is.";
+                    break;
+  
                   case RollStatus.Failure:
-                    return `Driving rain/hail (lowers visibility), blazing sunshine (potential heatstroke), living storm or bizarre weather phenomenon.`;
-                  
-                    default:
-                    throw new UnreachableCaseError(status)}
-                  })();
+                    descText += "Driving rain/hail (lowers visibility), blazing sunshine (potential heatstroke), living storm or bizarre weather phenomenon."
+                    break;
+              }
+              break;
 
-            default:
-              throw new UnreachableCaseError(rollType)}
+          default:
+            break;
+
+        }
+
+        if (doubles) {
+          switch (rollType) {
+
+              case WildType.Attack:
+                descText += "\n\n**(Twist... or Critical)**\n Unexpected narrative effect/critical with increased impact."
+
+              case WildType.Defense:
+                descText += "\n\n**(Twist... or Counter)**\n Unexpected narrative effect, or counter with a mark of damage against them (if in range)."  
+              break;
+              // Watch and Weather-watching rolls don't have twists
+              case WildType.Watch:
+                break;
+
+              case WildType.Weather:
+                break;
+
+              default:
+                descText += "\n\n**(Twist)**\nAdds a small, potentially useful twist, suggested by any player. Firefly has final say."
+                break;
+          }
+        }
+
+        if (zeroD) {
+          descText += "\n\n**(Zero Dice)**\nYou had nothing in your dice pool! Treat triumphs as conflicts."
+        }
+
+        return descText;
+
         })();     
 
 

--- a/src/interpreters/wildDice.ts
+++ b/src/interpreters/wildDice.ts
@@ -1,19 +1,87 @@
+import { IntegrationExpireBehavior } from "discord.js";
 import {
-    RollResponse,
-    Rolls,
-    WildType,
-    RollStatus,
-    UnreachableCaseError,
-  } from "../utils/lib";
+  RollResponse,
+  Rolls,
+  WildType,
+  RollStatus,
+  UnreachableCaseError,
+} from "../utils/lib";
   
-   export const wildDice = (
-     rolls: Rolls,
-     rollType: WildType,
-   ): RollResponse => {
-    return {
-      title: `Test`,
-      description: `Test.`,
-      status: RollStatus.Full,
-      dice: rolls.dice,
+export const wildDice = (
+  rolls: Rolls,
+  rollType: WildType,
+  zeroD: boolean,
+  cut: number
+): RollResponse => {
+
+    const pool = zeroD ? 0 : rolls.dice.length;
+    const score = rolls.max;
+    
+    const status: RollStatus =
+      zeroD ? score > 3
+             ? RollStatus.Mixed
+             : RollStatus.Failure
+
+        : (() => {
+          return score > 5
+          ? RollStatus.Full
+          : score > 3
+          ? RollStatus.Mixed
+          : RollStatus.Failure;
+        })();
+      
+    const title = (() => {
+      switch (rollType) {
+        case WildType.Watch:
+          return (() => {
+            switch (status) {
+              case RollStatus.Full:
+                return "Peace";
+              case RollStatus.Mixed:
+                return "Order";
+              case RollStatus.Failure:
+                return "Nature";
+              default:
+                throw new UnreachableCaseError(status);
+            }
+          })();
+        case WildType.Weather:
+          return (() => {
+            switch (status) {
+              case RollStatus.Full:
+                return "Clear Skies";
+              case RollStatus.Mixed:
+                return "Continuation";
+              case RollStatus.Failure:
+                return "A Change for the Worse";
+              default:
+                throw new UnreachableCaseError(status);
+              }
+            })();
+        default:
+          return (() => {
+            switch (status) {
+              case RollStatus.Full:
+                return "Triumph!";
+              case RollStatus.Mixed:
+                return "Conflict!";
+              case RollStatus.Failure:
+                return "Disaster!";
+              default:
+                throw new UnreachableCaseError(status);
+              }
+            })();
+      ;}
+      
+    })();
+
+        const description = "test";
+
+  return {
+    title,
+    description,
+    status,
+    dice: rolls.dice,
     };
+
   };

--- a/src/interpreters/wildDice.ts
+++ b/src/interpreters/wildDice.ts
@@ -1,0 +1,19 @@
+import {
+    RollResponse,
+    Rolls,
+    WildType,
+    RollStatus,
+    UnreachableCaseError,
+  } from "../utils/lib";
+  
+   export const wildDice = (
+     rolls: Rolls,
+     rollType: WildType,
+   ): RollResponse => {
+    return {
+      title: `Test`,
+      description: `Test.`,
+      status: RollStatus.Full,
+      dice: rolls.dice,
+    };
+  };

--- a/src/interpreters/wildDice.ts
+++ b/src/interpreters/wildDice.ts
@@ -1,4 +1,3 @@
-import { IntegrationExpireBehavior } from "discord.js";
 import {
   RollResponse,
   Rolls,
@@ -16,22 +15,24 @@ export const wildDice = (
 
 
   // TODO: cut
+  // TODO: reminder text on 0-dice rolls
 
     const pool = zeroD ? 0 : rolls.dice.length;
 
     const doubles: boolean = (() => {
-
+      // a little space/memory-inefficient, but hopefully not a dealbreaker
       if (rolls.dice.length !== new Set(rolls.dice).size) {
         return true;
       }
       return false;
     })();
 
+    if (cut === undefined || cut === null) cut = 0;
 
     const score = rolls.max;
     
     const status: RollStatus =
-      zeroD ? score > 3
+      zeroD ? score > 3 // with a pool of 0, roll 1d6, and count triumphs as conflicts
              ? RollStatus.Mixed
              : RollStatus.Failure
 
@@ -103,22 +104,28 @@ export const wildDice = (
        (() => {
 
           switch (rollType) {
-
+            // there is probably a way to avoid this deduplication for the twists text
             case WildType.Action:
+
               return (() => {
+
               switch (status) {
+
                 case RollStatus.Full:
                   return `Complete success, no drawbacks. Mark/clear a box on a track.${
-                    doubles ? " (Twist) Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
+                    doubles ? " \n\n**(Twist)**\n Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
                   }`;
+
                 case RollStatus.Mixed:
                   return `Success with a drawback. Usually marks/ clears a box.${
-                    doubles ? " (Twist) Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
+                    doubles ? " \n\n**(Twist)**\n Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
                   }`;
+
                 case RollStatus.Failure:
                   return `Failure and narrative complication or drawback. Usually doesn't mark/clear a box.${
-                    doubles ? " (Twist) Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
+                    doubles ? " \n\n**(Twist)**\n Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
                   }`;
+
                 default:
                   throw new UnreachableCaseError(status)}
               })(); 
@@ -126,18 +133,22 @@ export const wildDice = (
             case WildType.Attack:
               return (() => {
                 switch (status) {
+
                   case RollStatus.Full:
                     return `Powerful blow. Deal damage and might inflict an effect.${
-                      doubles ? " (Twist... or Critical) Unexpected narrative effect/critical with increased impact." : ""
+                      doubles ? " \n\n**(Twist... or Critical)**\n Unexpected narrative effect/critical with increased impact." : ""
                     }`;
+
                   case RollStatus.Mixed:
                     return `Attack deals damage and maybe associated effect, but you might take some damage, suffer an effect, lose a resource or be put in a less favourable position.${
-                      doubles ? " (Twist... or Critical) Unexpected narrative effect/critical with increased impact." : ""
+                      doubles ? " \n\n**(Twist... or Critical)**\n Unexpected narrative effect/critical with increased impact." : ""
                     }`;
+
                   case RollStatus.Failure:
-                    return `Failure and narrative complication or drawback. Usually doesn't mark/clear a box.${
-                      doubles ? " (Twist... or Critical) Unexpected narrative effect/critical with increased impact." : ""
+                    return `Attack misses or does no damage. You definitely take some damage or an effect, and might lose a resource or be put in a less favourable position too.${
+                      doubles ? " \n\n**(Twist... or Critical)**\n Unexpected narrative effect/critical with increased impact." : ""
                     }`;
+
                   default:
                     throw new UnreachableCaseError(status)}
                 })();
@@ -145,129 +156,156 @@ export const wildDice = (
             case WildType.Defense:
               return (() => {
                 switch (status) {
+
                   case RollStatus.Full:
                     return `Completely avoid the threat (though some powerful opponents may have aspects that make even a triumph dangerous).${
-                      doubles ? " (Twist...or Counter) Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
+                      doubles ? " \n\n**(Twist... or Counter)**\n Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
                     }`;
+
                   case RollStatus.Mixed:
                     return `Avoid the worst but take damage, an effect, a negative change in position, or destruction (or temporary denial) of a resource.${
-                      doubles ? " (Twist...or Counter) Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
+                      doubles ? " \n\n**(Twist... or Counter)**\n Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
                     }`;
+
                   case RollStatus.Failure:
                     return `Take damage, and likely associated effect and loss of resource or position as well.${
-                      doubles ? " (Twist...or Counter) Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
+                      doubles ? " \n\n**(Twist... or Counter)**\n Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
                     }`;
+
                   default:
                     throw new UnreachableCaseError(status)}
                   })();
 
-            case WildType.Resource:
+            case WildType.Acquisition:
               return (() => {
                 switch (status) {
+
                   case RollStatus.Full:
                     return `Gain a solid untainted resource.${
-                      doubles ? " (Twist) Gain a resource with a unique or positive tag suggested by you or another player." : ""
+                      doubles ? " \n\n**(Twist)**\n Gain a resource with a unique or positive tag suggested by you or another player." : ""
                     }`;
+
                   case RollStatus.Mixed:
                     return `Gain a resource with a negative tag.${
-                      doubles ? " (Twist) Gain a resource with a unique or positive tag suggested by you or another player." : ""
+                      doubles ? " \n\n**(Twist)**\n Gain a resource with a unique or positive tag suggested by you or another player." : ""
                     }`;
+
                   case RollStatus.Failure:
                     return `Resource not found or ruined during collection.${
-                      doubles ? " (Twist) Gain a resource with a unique or positive tag suggested by you or another player." : ""
+                      doubles ? " \n\n**(Twist)**\n Gain a resource with a unique or positive tag suggested by you or another player." : ""
                     }`;
+
                   default:
                     throw new UnreachableCaseError(status)}
                   })();
 
-              case WildType.Creation:
-                return (() => {
-                  switch (status) {
-                    case RollStatus.Full:
-                      return `Recipient gains temporary benefit related to resources used.${
-                        doubles ? " (Twist) Creation has small, unexpected benefit in addition to the usual result." : ""
-                      }`;
-                    case RollStatus.Mixed:
-                      return `Recipient gains temporary 2-track aspect with downsides, or no downside, but it doesn't quite do what was intended.${
-                        doubles ? " (Twist) Creation has small, unexpected benefit in addition to the usual result." : ""
-                      }`;
-                    case RollStatus.Failure:
-                      return `Creation might be a bizarre ornament/culinary curiosity, but gives no benefits.${
-                        doubles ? " (Twist) Creation has small, unexpected benefit in addition to the usual result." : ""
-                      }`;
-                    default:
-                      throw new UnreachableCaseError(status)}
-                    })();
+            case WildType.Creation:
+              return (() => {
+                switch (status) {
 
-              case WildType.Recovery:
-                return (() => {
-                  switch (status) {
-                    case RollStatus.Full:
-                      return `Heal two marks of damage to an aspect, ship rating, injury track or mire.${
-                        doubles ? " (Twist) You don’t consume the resource used to carry out your recovery." : ""
-                      }`;
-                    case RollStatus.Mixed:
-                      return `Heal one mark of damage to an aspect, ship rating, injury track or mire.${
-                        doubles ? " (Twist) You don’t consume the resource used to carry out your recovery." : ""
-                      }`;
-                    case RollStatus.Failure:
-                      return `Add an extra mark of damage to an aspect, ship rating, injury track or mire.${
-                        doubles ? " (Twist) You don’t consume the resource used to carry out your recovery." : ""
-                      }`;
-                    default:
-                      throw new UnreachableCaseError(status)}
-                    })();
+                  case RollStatus.Full:
+                    return `Recipient gains temporary benefit related to resources used.${
+                      doubles ? " \n\n**(Twist)**\n Creation has small, unexpected benefit in addition to the usual result." : ""
+                    }`;
 
-                case WildType.Ratings:
-                  return (() => {
-                    switch (status) {
-                      case RollStatus.Full:
-                        return `Bypass the obstacle safely.${
-                          doubles ? " (Twist) An unexpected event in addition to the result." : ""
-                        }`;
-                      case RollStatus.Mixed:
-                        return `Bypass the obstacle but mark 1 Rating damage.${
-                          doubles ? " (Twist) An unexpected event in addition to the result." : ""
-                        }`;
-                      case RollStatus.Failure:
-                        return `Fail to bypass the obstacle and mark 1 Rating damage.${
-                          doubles ? " (Twist) An unexpected event in addition to the result." : ""
-                        }`;
-                      default:
-                        throw new UnreachableCaseError(status)}
-                      })();
+                  case RollStatus.Mixed:
+                    return `Recipient gains temporary 2-track aspect with downsides, or no downside, but it doesn't quite do what was intended.${
+                      doubles ? " \n\n**(Twist)**\n Creation has small, unexpected benefit in addition to the usual result." : ""
+                    }`;
+
+                  case RollStatus.Failure:
+                    return `Creation might be a bizarre ornament/culinary curiosity, but gives no benefits.${
+                      doubles ? " \n\n**(Twist)**\n Creation has small, unexpected benefit in addition to the usual result." : ""
+                    }`;
+
+                  default:
+                    throw new UnreachableCaseError(status)}
+                  })();
+
+            case WildType.Recovery:
+              return (() => {
+                switch (status) {
+
+                  case RollStatus.Full:
+                    return `Heal two marks of damage to an aspect, ship rating, injury track or mire.${
+                      doubles ? " \n\n**(Twist)**\n You don't consume the resource used to carry out your recovery." : ""
+                    }`;
+
+                  case RollStatus.Mixed:
+                    return `Heal one mark of damage to an aspect, ship rating, injury track or mire.${
+                      doubles ? " \n\n**(Twist)**\n You don't consume the resource used to carry out your recovery." : ""
+                    }`;
+
+                  case RollStatus.Failure:
+                    return `Add an extra mark of damage to an aspect, ship rating, injury track or mire.${
+                      doubles ? " \n\n**(Twist)**\n You don't consume the resource used to carry out your recovery." : ""
+                    }`;
+
+                  default:
+                    throw new UnreachableCaseError(status)}
+                  })();
+
+            case WildType.Ratings:
+              return (() => {
+                switch (status) {
+
+                  case RollStatus.Full:
+                    return `Bypass the obstacle safely.${
+                      doubles ? " \n\n**(Twist)**\n An unexpected event in addition to the result." : ""
+                    }`;
+
+                  case RollStatus.Mixed:
+                    return `Bypass the obstacle but mark 1 Rating damage.${
+                      doubles ? " \n\n**(Twist)**\n An unexpected event in addition to the result." : ""
+                    }`;
+
+                  case RollStatus.Failure:
+                    return `Fail to bypass the obstacle and mark 1 Rating damage.${
+                      doubles ? " \n\n**(Twist)**\n An unexpected event in addition to the result." : ""
+                    }`;
+
+                  default:
+                    throw new UnreachableCaseError(status)}
+                  })();
 
                 // Watch and Weather-Watching don't have twist results
 
-                case WildType.Watch:
-                  return (() => {
-                    switch (status) {
-                      case RollStatus.Full:
-                        return `Montage, Meeting, Tall Tale (gain a Whisper), Tree Shanty, Undercrew Issue, Reflection (heal Mire)`;
-                      case RollStatus.Mixed:
-                        return `Nearby Ship, Outpost, Survivor Needing Rescue, Wreck or Ruin, Cache of Cargo/Supplies, Conspiracy`;
-                      case RollStatus.Failure:
-                        return `Weather, Natural Feature, Wonder (heal Mire), Horror, Unsettled Landfall, True Wilds`;
-                      default:
-                        throw new UnreachableCaseError(status)}
-                      })();
+            case WildType.Watch:
+              return (() => {
+                switch (status) {
 
-                case WildType.Weather:
-                  return (() => {
-                    switch (status) {
-                      case RollStatus.Full:
-                        return `Weather clears.`;
-                      case RollStatus.Mixed:
-                        return `Weather continues as it is.`;
-                      case RollStatus.Failure:
-                        return `Driving rain/hail (lowers visibility), blazing sunshine (potential heathstroke), living storm or bizarre weather phenomenon.`;
-                      default:
-                        throw new UnreachableCaseError(status)}
-                      })();
+                  case RollStatus.Full:
+                    return `Montage, Meeting, Tall Tale (gain a Whisper), Tree Shanty, Undercrew Issue, Reflection (heal Mire)`;
+             
+                  case RollStatus.Mixed:
+                    return `Nearby Ship, Outpost, Survivor Needing Rescue, Wreck or Ruin, Cache of Cargo/Supplies, Conspiracy`;
+            
+                  case RollStatus.Failure:
+                    return `Weather, Natural Feature, Wonder (heal Mire), Horror, Unsettled Landfall, True Wilds`;
+            
+                  default:
+                    throw new UnreachableCaseError(status)}
+                  })();
 
+            case WildType.Weather:
+              return (() => {
+                switch (status) {
 
-              default:
-                throw new UnreachableCaseError(rollType)}
+                  case RollStatus.Full:
+                    return `Weather clears.`;
+                  
+                  case RollStatus.Mixed:
+                    return `Weather continues as it is.`;
+                  
+                  case RollStatus.Failure:
+                    return `Driving rain/hail (lowers visibility), blazing sunshine (potential heatstroke), living storm or bizarre weather phenomenon.`;
+                  
+                    default:
+                    throw new UnreachableCaseError(status)}
+                  })();
+
+            default:
+              throw new UnreachableCaseError(rollType)}
         })();     
 
 

--- a/src/interpreters/wildDice.ts
+++ b/src/interpreters/wildDice.ts
@@ -11,7 +11,7 @@ export const wildDice = (
   rolls: Rolls,
   rollType: WildType,
   zeroD: boolean,
-  cut: number
+  cut?: number
 ): RollResponse => {
 
     const pool = zeroD ? 0 : rolls.dice.length;

--- a/src/interpreters/wildDice.ts
+++ b/src/interpreters/wildDice.ts
@@ -105,210 +105,187 @@ export const wildDice = (
 
     const description =
        (() => {
+        let descText = "";
 
-          switch (rollType) {
-            // there is probably a way to avoid this deduplication for the twists text
-            case WildType.Action:
+        switch (rollType) {
 
-              return (() => {
-
-              switch (status) {
-
+          case WildType.Action:
+            switch (status) {
                 case RollStatus.Full:
-                  return `Complete success, no drawbacks. Mark/clear a box on a track.${
-                    doubles ? " \n\n**(Twist)**\n Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
-                  }`;
+                  descText += "Complete success, no drawbacks. Mark/clear a box on a track.";
+                  break;
 
                 case RollStatus.Mixed:
-                  return `Success with a drawback. Usually marks/ clears a box.${
-                    doubles ? " \n\n**(Twist)**\n Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
-                  }`;
+                  descText += "Success with a drawback. Usually marks/ clears a box.";
+                  break;
 
                 case RollStatus.Failure:
-                  return `Failure and narrative complication or drawback. Usually doesn't mark/clear a box.${
-                    doubles ? " \n\n**(Twist)**\n Adds a small, potentially useful twist, suggested by any player. Firefly has final say." : ""
-                  }`;
+                  descText += "Failure and narrative complication or drawback. Usually doesn't mark/clear a box."
+                  break;
+            }
+            break;
 
-                default:
-                  throw new UnreachableCaseError(status)}
-              })(); 
-              
-            case WildType.Attack:
-              return (() => {
-                switch (status) {
+          case WildType.Attack:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Powerful blow. Deal damage and might inflict an effect.";
+                  break;
 
-                  case RollStatus.Full:
-                    return `Powerful blow. Deal damage and might inflict an effect.${
-                      doubles ? " \n\n**(Twist... or Critical)**\n Unexpected narrative effect/critical with increased impact." : ""
-                    }`;
+                case RollStatus.Mixed:
+                  descText += "Attack deals damage and maybe associated effect, but you might take some damage, suffer an effect, lose a resource or be put in a less favourable position.";
+                  break;
 
-                  case RollStatus.Mixed:
-                    return `Attack deals damage and maybe associated effect, but you might take some damage, suffer an effect, lose a resource or be put in a less favourable position.${
-                      doubles ? " \n\n**(Twist... or Critical)**\n Unexpected narrative effect/critical with increased impact." : ""
-                    }`;
+                case RollStatus.Failure:
+                  descText += "Attack misses or does no damage. You definitely take some damage or an effect, and might lose a resource or be put in a less favourable position too."
+                  break;
+            }
+            break;
+  
+          case WildType.Defense:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Completely avoid the threat (though some powerful opponents may have aspects that make even a triumph dangerous).";
+                  break;
 
-                  case RollStatus.Failure:
-                    return `Attack misses or does no damage. You definitely take some damage or an effect, and might lose a resource or be put in a less favourable position too.${
-                      doubles ? " \n\n**(Twist... or Critical)**\n Unexpected narrative effect/critical with increased impact." : ""
-                    }`;
+                case RollStatus.Mixed:
+                  descText += "Avoid the worst but take damage, an effect, a negative change in position, or destruction (or temporary denial) of a resource.";
+                  break;
 
-                  default:
-                    throw new UnreachableCaseError(status)}
-                })();
+                case RollStatus.Failure:
+                  descText += "Take damage, and likely associated effect and loss of resource or position as well."
+                  break;
+            }
+            break;
 
-            case WildType.Defense:
-              return (() => {
-                switch (status) {
+          case WildType.Acquisition:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Gain a solid untainted resource.";
+                  break;
 
-                  case RollStatus.Full:
-                    return `Completely avoid the threat (though some powerful opponents may have aspects that make even a triumph dangerous).${
-                      doubles ? " \n\n**(Twist... or Counter)**\n Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
-                    }`;
+                case RollStatus.Mixed:
+                  descText += "Gain a resource with a negative tag.";
+                  break;
 
-                  case RollStatus.Mixed:
-                    return `Avoid the worst but take damage, an effect, a negative change in position, or destruction (or temporary denial) of a resource.${
-                      doubles ? " \n\n**(Twist... or Counter)**\n Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
-                    }`;
+                case RollStatus.Failure:
+                  descText += "Resource not found or ruined during collection."
+                  break;
+            }
+            break;
 
-                  case RollStatus.Failure:
-                    return `Take damage, and likely associated effect and loss of resource or position as well.${
-                      doubles ? " \n\n**(Twist... or Counter)**\n Unexpected narrative effect, or counter with a mark of damage against them (if in range)." : ""
-                    }`;
+          case WildType.Creation:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Recipient gains temporary benefit related to resources used.";
+                  break;
 
-                  default:
-                    throw new UnreachableCaseError(status)}
-                  })();
+                case RollStatus.Mixed:
+                  descText += "Recipient gains temporary 2-track aspect with downsides, or no downside, but it doesn't quite do what was intended.";
+                  break;
 
-            case WildType.Acquisition:
-              return (() => {
-                switch (status) {
+                case RollStatus.Failure:
+                  descText += "Creation might be a bizarre ornament/culinary curiosity, but gives no benefits."
+                  break;
+            }
+            break;
 
-                  case RollStatus.Full:
-                    return `Gain a solid untainted resource.${
-                      doubles ? " \n\n**(Twist)**\n Gain a resource with a unique or positive tag suggested by you or another player." : ""
-                    }`;
+          case WildType.Recovery:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Heal two marks of damage to an aspect, ship rating, injury track or mire.";
+                  break;
 
-                  case RollStatus.Mixed:
-                    return `Gain a resource with a negative tag.${
-                      doubles ? " \n\n**(Twist)**\n Gain a resource with a unique or positive tag suggested by you or another player." : ""
-                    }`;
+                case RollStatus.Mixed:
+                  descText += "Heal one mark of damage to an aspect, ship rating, injury track or mire.";
+                  break;
 
-                  case RollStatus.Failure:
-                    return `Resource not found or ruined during collection.${
-                      doubles ? " \n\n**(Twist)**\n Gain a resource with a unique or positive tag suggested by you or another player." : ""
-                    }`;
+                case RollStatus.Failure:
+                  descText += "Add an extra mark of damage to an aspect, ship rating, injury track or mire."
+                  break;
+            }
+            break;
 
-                  default:
-                    throw new UnreachableCaseError(status)}
-                  })();
+          case WildType.Ratings:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Bypass the obstacle safely.";
+                  break;
 
-            case WildType.Creation:
-              return (() => {
-                switch (status) {
+                case RollStatus.Mixed:
+                  descText += "Bypass the obstacle but mark 1 Rating damage.";
+                  break;
 
-                  case RollStatus.Full:
-                    return `Recipient gains temporary benefit related to resources used.${
-                      doubles ? " \n\n**(Twist)**\n Creation has small, unexpected benefit in addition to the usual result." : ""
-                    }`;
+                case RollStatus.Failure:
+                  descText += "Fail to bypass the obstacle and mark 1 Rating damage."
+                  break;
+            }
+            break;
 
-                  case RollStatus.Mixed:
-                    return `Recipient gains temporary 2-track aspect with downsides, or no downside, but it doesn't quite do what was intended.${
-                      doubles ? " \n\n**(Twist)**\n Creation has small, unexpected benefit in addition to the usual result." : ""
-                    }`;
+          case WildType.Watch:
+            switch (status) {
+                case RollStatus.Full:
+                  descText += "Montage, Meeting, Tall Tale (gain a Whisper), Tree Shanty, Undercrew Issue, Reflection (heal Mire)";
+                  break;
 
-                  case RollStatus.Failure:
-                    return `Creation might be a bizarre ornament/culinary curiosity, but gives no benefits.${
-                      doubles ? " \n\n**(Twist)**\n Creation has small, unexpected benefit in addition to the usual result." : ""
-                    }`;
+                case RollStatus.Mixed:
+                  descText += "Nearby Ship, Outpost, Survivor Needing Rescue, Wreck or Ruin, Cache of Cargo/Supplies, Conspiracy";
+                  break;
 
-                  default:
-                    throw new UnreachableCaseError(status)}
-                  })();
-
-            case WildType.Recovery:
-              return (() => {
-                switch (status) {
-
-                  case RollStatus.Full:
-                    return `Heal two marks of damage to an aspect, ship rating, injury track or mire.${
-                      doubles ? " \n\n**(Twist)**\n You don't consume the resource used to carry out your recovery." : ""
-                    }`;
-
-                  case RollStatus.Mixed:
-                    return `Heal one mark of damage to an aspect, ship rating, injury track or mire.${
-                      doubles ? " \n\n**(Twist)**\n You don't consume the resource used to carry out your recovery." : ""
-                    }`;
-
-                  case RollStatus.Failure:
-                    return `Add an extra mark of damage to an aspect, ship rating, injury track or mire.${
-                      doubles ? " \n\n**(Twist)**\n You don't consume the resource used to carry out your recovery." : ""
-                    }`;
-
-                  default:
-                    throw new UnreachableCaseError(status)}
-                  })();
-
-            case WildType.Ratings:
-              return (() => {
-                switch (status) {
-
-                  case RollStatus.Full:
-                    return `Bypass the obstacle safely.${
-                      doubles ? " \n\n**(Twist)**\n An unexpected event in addition to the result." : ""
-                    }`;
-
-                  case RollStatus.Mixed:
-                    return `Bypass the obstacle but mark 1 Rating damage.${
-                      doubles ? " \n\n**(Twist)**\n An unexpected event in addition to the result." : ""
-                    }`;
-
-                  case RollStatus.Failure:
-                    return `Fail to bypass the obstacle and mark 1 Rating damage.${
-                      doubles ? " \n\n**(Twist)**\n An unexpected event in addition to the result." : ""
-                    }`;
-
-                  default:
-                    throw new UnreachableCaseError(status)}
-                  })();
-
-                // Watch and Weather-Watching don't have twist results
-
-            case WildType.Watch:
-              return (() => {
-                switch (status) {
-
-                  case RollStatus.Full:
-                    return `Montage, Meeting, Tall Tale (gain a Whisper), Tree Shanty, Undercrew Issue, Reflection (heal Mire)`;
-             
-                  case RollStatus.Mixed:
-                    return `Nearby Ship, Outpost, Survivor Needing Rescue, Wreck or Ruin, Cache of Cargo/Supplies, Conspiracy`;
-            
-                  case RollStatus.Failure:
-                    return `Weather, Natural Feature, Wonder (heal Mire), Horror, Unsettled Landfall, True Wilds`;
-            
-                  default:
-                    throw new UnreachableCaseError(status)}
-                  })();
+                case RollStatus.Failure:
+                  descText += "Weather, Natural Feature, Wonder (heal Mire), Horror, Unsettled Landfall, True Wilds"
+                  break;
+            }
+            break;
 
             case WildType.Weather:
-              return (() => {
-                switch (status) {
-
+              switch (status) {
                   case RollStatus.Full:
-                    return `Weather clears.`;
-                  
+                    descText += "Weather clears.";
+                    break;
+  
                   case RollStatus.Mixed:
-                    return `Weather continues as it is.`;
-                  
+                    descText += "Weather continues as it is.";
+                    break;
+  
                   case RollStatus.Failure:
-                    return `Driving rain/hail (lowers visibility), blazing sunshine (potential heatstroke), living storm or bizarre weather phenomenon.`;
-                  
-                    default:
-                    throw new UnreachableCaseError(status)}
-                  })();
+                    descText += "Driving rain/hail (lowers visibility), blazing sunshine (potential heatstroke), living storm or bizarre weather phenomenon."
+                    break;
+              }
+              break;
 
-            default:
-              throw new UnreachableCaseError(rollType)}
+          default:
+            break;
+
+        }
+
+        if (doubles) {
+          switch (rollType) {
+
+              case WildType.Attack:
+                descText += "\n\n**(Twist... or Critical)**\n Unexpected narrative effect/critical with increased impact."
+                break;
+              case WildType.Defense:
+                descText += "\n\n**(Twist... or Counter)**\n Unexpected narrative effect, or counter with a mark of damage against them (if in range)."  
+                break;
+              // Watch and Weather-watching rolls don't have twists
+              case WildType.Watch:
+                break;
+
+              case WildType.Weather:
+                break;
+
+              default:
+                descText += "\n\n**(Twist)**\nAdds a small, potentially useful twist, suggested by any player. Firefly has final say."
+                break;
+          }
+        }
+
+        if (zeroD) {
+          descText += "\n\n**(Zero Dice)**\nYou had nothing in your dice pool! Treat triumphs as conflicts."
+        }
+
+        return descText;
+
         })();     
 
 

--- a/src/interpreters/wildDice.ts
+++ b/src/interpreters/wildDice.ts
@@ -45,60 +45,63 @@ export const wildDice = (
         })();
       
     const title = (() => {
+
+      let titleText = `(${rollType}) `;
+
       switch (rollType) {
         case WildType.Watch:
-          return (() => {
+       //   return (() => {
             switch (status) {
               case RollStatus.Full:
-                return `(${rollType}) Peace`;
+                titleText += `Peace`;
+                break;
               case RollStatus.Mixed:
-                return `(${rollType}) Order`;
+                titleText += `Order`;
+                break;
               case RollStatus.Failure:
-                return `(${rollType}) Nature`;
+                titleText += `Nature`;
+                break;
               default:
-                throw new UnreachableCaseError(status);
-            }
-          })();
+                break;
+           }
+          break;
         case WildType.Weather:
-          return (() => {
             switch (status) {
               case RollStatus.Full:
-                return `(${rollType}) Clear Skies`;
+                 titleText += `Clear Skies`;
+                 break;
               case RollStatus.Mixed:
-                return `(${rollType}) Continuation`;
+                 titleText += `Continuation`;
+                 break;
               case RollStatus.Failure:
-                return `(${rollType}) A Change for the Worse`;
+                 titleText += `A Change for the Worse`;
+                 break;
               default:
-                throw new UnreachableCaseError(status);
+                  break;
               }
-            })();
+          break;
         default:
-          return (() => {
             switch (status) {
 
               case RollStatus.Full:
-                return `(${rollType}) Triumph${
-                  doubles ? " with a twist" : ""
-                }!`;
+                 titleText += "Triumph";
+                 break;
 
               case RollStatus.Mixed:
-                return `(${rollType}) Conflict${
-                  doubles ? " with a twist" : ""
-                }!`; 
+                 titleText += "Conflict"; 
+                 break;
                 
               case RollStatus.Failure:
-                return `(${rollType}) Disaster${
-                  doubles ? " with a twist" : ""
-                }!`;
+               titleText += "Disaster";
+               break;
 
-                default:
-                throw new UnreachableCaseError(status);
+              default:
+                break;
               }
-            })();
- 
-      ;}
+          }
 
-    })();
+            return (doubles && ((rollType !== WildType.Watch) && (rollType !== WildType.Weather))) ? titleText += " with a twist!" : titleText += "!";
+      ;})();
 
     const description =
        (() => {

--- a/src/utils/lib.ts
+++ b/src/utils/lib.ts
@@ -21,7 +21,7 @@ export enum WildType {
   Recovery = "recovery",
   Ratings = "ratings",
   Watch = "watch",
-  Weather = "weather"
+  Weather = "weather",
 }
 
 export interface RollResponse {

--- a/src/utils/lib.ts
+++ b/src/utils/lib.ts
@@ -12,6 +12,18 @@ export enum ForgedType {
   Clear = "clear",
 }
 
+export enum WildType {
+  Action = "action",
+  Attack = "attack",
+  Defense = "defense",
+  Acquisition = "acquisition",
+  Creation = "creation",
+  Recovery = "recovery",
+  Ratings = "ratings",
+  Watch = "watch",
+  Weather = "weather"
+}
+
 export interface RollResponse {
   title: string;
   description: string;

--- a/src/utils/lib.ts
+++ b/src/utils/lib.ts
@@ -13,15 +13,15 @@ export enum ForgedType {
 }
 
 export enum WildType {
-  Action = "action",
-  Attack = "attack",
-  Defense = "defense",
-  Acquisition = "acquisition",
-  Creation = "creation",
-  Recovery = "recovery",
-  Ratings = "ratings",
-  Watch = "watch",
-  Weather = "weather",
+  Action = "Action",
+  Attack = "Attack",
+  Defense = "Defense",
+  Resource = "Resource",
+  Creation = "Creation",
+  Recovery = "Recovery",
+  Ratings = "Ratings",
+  Watch = "Watch",
+  Weather = "Weather-watching",
 }
 
 export interface RollResponse {

--- a/src/utils/lib.ts
+++ b/src/utils/lib.ts
@@ -16,7 +16,7 @@ export enum WildType {
   Action = "Action",
   Attack = "Attack",
   Defense = "Defense",
-  Resource = "Resource",
+  Acquisition = "Acquisition",
   Creation = "Creation",
   Recovery = "Recovery",
   Ratings = "Ratings",

--- a/src/utils/lib.ts
+++ b/src/utils/lib.ts
@@ -55,3 +55,7 @@ export const rollDice = (count: number, sides: number): Rolls => {
     dice,
   };
 };
+
+export function compareNumbers(a: number, b: number) {
+  return a - b;
+}

--- a/src/utils/rollCommandBuilders.ts
+++ b/src/utils/rollCommandBuilders.ts
@@ -93,15 +93,15 @@ export const pbtaCommand = (subcommand: SlashCommandSubcommandBuilder) =>
             .setDescription("The type of roll you'd like to make.")
             .setRequired(true)
             .addChoices(
-                { name: "action", value: "action"},
-                { name: "attack", value: "attack"},
-                { name: "defense", value: "defense"},
-                { name: "acquisition", value: "acquisition"},
-                { name: "creation", value: "creation"},
-                { name: "recovery", value: "recovery"},
-                { name: "ratings", value: "ratings"},
-                { name: "watch", value: "watch"},
-                { name: "weather-watching", value: "weather"}
+                { name: "Action", value: "action"},
+                { name: "Attack", value: "attack"},
+                { name: "Defense", value: "defense"},
+                { name: "Acquisition", value: "acquisition"},
+                { name: "Creation", value: "creation"},
+                { name: "Recovery", value: "recovery"},
+                { name: "Ratings", value: "ratings"},
+                { name: "Watch", value: "watch"},
+                { name: "Weather-watching", value: "weather"}
             )
           )
           .addIntegerOption((option) =>
@@ -110,12 +110,15 @@ export const pbtaCommand = (subcommand: SlashCommandSubcommandBuilder) =>
             .setDescription("The size of your dice pool.")
             .setRequired(true)
             .setMinValue(0)
+            .setMaxValue(6)
           )
   
           .addIntegerOption((option) =>
           option
             .setName("cut")
-            .setDescription("The number of dice to cut from the result pool")
+            .setDescription("The number of results to remove from the result pool, starting from the highest.")
             .setRequired(false)
+            .setMinValue(0)
+            .setMaxValue(6)
         ); 
       

--- a/src/utils/rollCommandBuilders.ts
+++ b/src/utils/rollCommandBuilders.ts
@@ -93,15 +93,15 @@ export const pbtaCommand = (subcommand: SlashCommandSubcommandBuilder) =>
             .setDescription("The type of roll you'd like to make.")
             .setRequired(true)
             .addChoices(
-                { name: "Action", value: "action"},
-                { name: "Attack", value: "attack"},
-                { name: "Defense", value: "defense"},
-                { name: "Acquisition", value: "acquisition"},
-                { name: "Creation", value: "creation"},
-                { name: "Recovery", value: "recovery"},
-                { name: "Ratings", value: "ratings"},
-                { name: "Watch", value: "watch"},
-                { name: "Weather-watching", value: "weather"}
+                { name: "Action", value: "Action"},
+                { name: "Attack", value: "Attack"},
+                { name: "Defense", value: "Defense"},
+                { name: "Resource", value: "Resource"},
+                { name: "Creation", value: "Creation"},
+                { name: "Recovery", value: "Recovery"},
+                { name: "Ratings", value: "Ratings"},
+                { name: "Watch", value: "Watch"},
+                { name: "Weather-watching", value: "Weather-watching"}
             )
           )
           .addIntegerOption((option) =>

--- a/src/utils/rollCommandBuilders.ts
+++ b/src/utils/rollCommandBuilders.ts
@@ -82,3 +82,40 @@ export const pbtaCommand = (subcommand: SlashCommandSubcommandBuilder) =>
         )
         .setRequired(true)
     );
+
+    export const wildCommand = (subcommand: SlashCommandSubcommandBuilder) =>
+    subcommand    
+        .setName("wild")
+        .setDescription("Rolls a Wild Words roll.")
+        .addStringOption((option) =>
+        option
+            .setName("type")
+            .setDescription("The type of roll you'd like to make.")
+            .setRequired(true)
+            .addChoices(
+                { name: "action", value: "action"},
+                { name: "attack", value: "attack"},
+                { name: "defense", value: "defense"},
+                { name: "acquisition", value: "acquisition"},
+                { name: "creation", value: "creation"},
+                { name: "recovery", value: "recovery"},
+                { name: "ratings", value: "ratings"},
+                { name: "watch", value: "watch"},
+                { name: "weather-watching", value: "weather"}
+            )
+          )
+          .addIntegerOption((option) =>
+          option
+            .setName("pool")
+            .setDescription("The size of your dice pool.")
+            .setRequired(true)
+            .setMinValue(0)
+          )
+  
+          .addIntegerOption((option) =>
+          option
+            .setName("cut")
+            .setDescription("The number of dice to cut from the result pool")
+            .setRequired(false)
+        ); 
+      

--- a/src/utils/rollCommandBuilders.ts
+++ b/src/utils/rollCommandBuilders.ts
@@ -96,7 +96,7 @@ export const pbtaCommand = (subcommand: SlashCommandSubcommandBuilder) =>
                 { name: "Action", value: "Action"},
                 { name: "Attack", value: "Attack"},
                 { name: "Defense", value: "Defense"},
-                { name: "Resource", value: "Resource"},
+                { name: "Acquisition", value: "Acquisition"},
                 { name: "Creation", value: "Creation"},
                 { name: "Recovery", value: "Recovery"},
                 { name: "Ratings", value: "Ratings"},


### PR DESCRIPTION
Adds a `/roll wild` subcommand for handling Wild Words engine rolls, as seen in [The Wildsea](https://felixisaacs.itch.io/thewildsea) (and other games in the future, hopefully).

Currently supports the nine main types of rolls in The Wildsea, including handling **twists** (doubles), but not **cut**, nor any optional rules like alternate twists, Mayfly rolls, or Pressure effect rolls from the Storm & Root expansion. 

Rolling with a pool of 0 rolls 1d6 and treats triumphs (6s) as conflicts (4/5s), though this isn't indicated in the output.

~~(`/sparks-help` text also does not yet have WW roll information.)~~

